### PR TITLE
fix(playlist): More robust handling of the passed objects.

### DIFF
--- a/tidalapi/session.py
+++ b/tidalapi/session.py
@@ -361,7 +361,7 @@ class Session:
     def parse_playlist(self, obj: JsonObj) -> playlist.Playlist:
         """Parse a playlist from the given response."""
         # Note: When parsing playlists from v2 response, "data" field must be parsed
-        return self.playlist().parse(obj["data"])
+        return self.playlist().parse(obj.get("data", obj))
 
     def parse_folder(self, obj: JsonObj) -> playlist.Folder:
         """Parse an album from the given response."""


### PR DESCRIPTION
Apparently we can't always assume that the JSON object passed to `parse_playlist` always contains a `data` envelope.

Closes: #349