### PR TITLE
Feature: Fix playlist v2 endpoint usage. Add pagination workers from mopidy-tidal

### DIFF
--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -68,10 +68,10 @@ def test_get_user_playlists(session):
 def test_get_playlist_folders(session):
     folder = session.user.create_folder(title="testfolder")
     assert folder
-    folder_ids = [folder.id for folder in session.user.playlist_folders()]
+    folder_ids = [folder.id for folder in session.user.favorites.playlist_folders()]
     assert folder.id in folder_ids
     folder.remove()
-    folder_ids = [folder.id for folder in session.user.playlist_folders()]
+    folder_ids = [folder.id for folder in session.user.favorites.playlist_folders()]
     assert folder.id not in folder_ids
 
 

--- a/tidalapi/playlist.py
+++ b/tidalapi/playlist.py
@@ -88,12 +88,14 @@ class Playlist:
                 self._etag = request.headers["etag"]
                 self.parse(request.json())
 
-    def parse(self, json_obj: JsonObj) -> "Playlist":
+    def parse(self, obj: JsonObj) -> "Playlist":
         """Parses a playlist from tidal, replaces the current playlist object.
 
-        :param json_obj: Json data returned from api.tidal.com containing a playlist
+        :param obj: Json data returned from api.tidal.com containing a playlist
         :return: Returns a copy of the original :exc: 'Playlist': object
         """
+        json_obj = obj.get("data", obj)
+
         self.id = json_obj["uuid"]
         self.trn = f"trn:playlist:{self.id}"
         self.name = json_obj["title"]

--- a/tidalapi/session.py
+++ b/tidalapi/session.py
@@ -361,7 +361,7 @@ class Session:
     def parse_playlist(self, obj: JsonObj) -> playlist.Playlist:
         """Parse a playlist from the given response."""
         # Note: When parsing playlists from v2 response, "data" field must be parsed
-        return self.playlist().parse(obj.get("data", obj))
+        return self.playlist().parse(obj)
 
     def parse_folder(self, obj: JsonObj) -> playlist.Folder:
         """Parse an album from the given response."""

--- a/tidalapi/user.py
+++ b/tidalapi/user.py
@@ -159,36 +159,6 @@ class LoggedInUser(FetchedUser):
             ),
         )
 
-    def playlist_folders(
-        self, offset: int = 0, limit: int = 50, parent_folder_id: str = "root"
-    ) -> List["Folder"]:
-        """Get a list of folders created by the user.
-
-        :param offset: The amount of items you want returned.
-        :param limit: The index of the first item you want included.
-        :param parent_folder_id: Parent folder ID. Default: 'root' playlist folder
-        :return: Returns a list of :class:`~tidalapi.playlist.Folder` objects containing the Folders.
-        """
-        params = {
-            "folderId": parent_folder_id,
-            "offset": offset,
-            "limit": limit,
-            "order": "NAME",
-            "includeOnly": "FOLDER",
-        }
-        endpoint = "my-collection/playlists/folders"
-        return cast(
-            List["Folder"],
-            self.session.request.map_request(
-                url=urljoin(
-                    self.session.config.api_v2_location,
-                    endpoint,
-                ),
-                params=params,
-                parse=self.session.parse_folder,
-            ),
-        )
-
     def public_playlists(
         self, offset: int = 0, limit: int = 50
     ) -> List[Union["Playlist", "UserPlaylist"]]:
@@ -638,10 +608,10 @@ class Favorites:
         order: Optional[PlaylistOrder] = None,
         order_direction: Optional[OrderDirection] = None,
     ) -> List["Playlist"]:
-        """Get the users favorite playlists (v2 endpoint)
+        """Get the users favorite playlists (v2 endpoint), relative to the root folder
 
-        :param limit: Optional; The amount of playlists you want returned.
-        :param offset: The index of the first playlist you want included.
+        :param limit: Optional; The number of playlists you want returned (Note: Cannot exceed 50)
+        :param offset: The index of the first playlist to fetch
         :param order: Optional; A :class:`PlaylistOrder` describing the ordering type when returning the user favorite playlists. eg.: "NAME, "DATE"
         :param order_direction: Optional; A :class:`OrderDirection` describing the ordering direction when sorting by `order`. eg.: "ASC", "DESC"
         :return: A :class:`list` :class:`~tidalapi.playlist.Playlist` objects containing the favorite playlists.
@@ -667,6 +637,48 @@ class Favorites:
                 ),
                 params=params,
                 parse=self.session.parse_playlist,
+            ),
+        )
+
+    def playlist_folders(
+        self,
+        limit: Optional[int] = 50,
+        offset: int = 0,
+        order: Optional[PlaylistOrder] = None,
+        order_direction: Optional[OrderDirection] = None,
+        parent_folder_id: str = "root",
+    ) -> List["Folder"]:
+        """Get a list of folders created by the user.
+
+        :param limit: Optional; The number of playlists you want returned (Note: Cannot exceed 50)
+        :param offset: The index of the first playlist folder to fetch
+        :param order: Optional; A :class:`PlaylistOrder` describing the ordering type when returning the user favorite playlists. eg.: "NAME, "DATE"
+        :param order_direction: Optional; A :class:`OrderDirection` describing the ordering direction when sorting by `order`. eg.: "ASC", "DESC"
+        :param parent_folder_id: Parent folder ID. Default: 'root' playlist folder
+        :return: Returns a list of :class:`~tidalapi.playlist.Folder` objects containing the Folders.
+        """
+        params = {
+            "folderId": parent_folder_id,
+            "offset": offset,
+            "limit": limit,
+            "order": "NAME",
+            "includeOnly": "FOLDER",
+        }
+        if order:
+            params["order"] = order.value
+        if order_direction:
+            params["orderDirection"] = order_direction.value
+
+        endpoint = "my-collection/playlists/folders"
+        return cast(
+            List["Folder"],
+            self.session.request.map_request(
+                url=urljoin(
+                    self.session.config.api_v2_location,
+                    endpoint,
+                ),
+                params=params,
+                parse=self.session.parse_folder,
             ),
         )
 

--- a/tidalapi/user.py
+++ b/tidalapi/user.py
@@ -650,14 +650,14 @@ class Favorites:
             "folderId": "root",
             "offset": offset,
             "limit": limit,
-            "includeOnly": "",
+            "includeOnly": "PLAYLIST",  # Include only PLAYLIST types, FOLDER will be ignored
         }
         if order:
             params["order"] = order.value
         if order_direction:
             params["orderDirection"] = order_direction.value
 
-        endpoint = "my-collection/playlists/folders"
+        endpoint = "my-collection/playlists"
         return cast(
             List["Playlist"],
             self.session.request.map_request(

--- a/tidalapi/user.py
+++ b/tidalapi/user.py
@@ -549,7 +549,7 @@ class Favorites:
         order: Optional[ArtistOrder] = None,
         order_direction: Optional[OrderDirection] = None,
     ) -> List["Artist"]:
-        """Get the users favorite artists, using pagination
+        """Get the users favorite artists, using pagination.
 
         :param order: Optional; A :class:`ArtistOrder` describing the ordering type when returning the user favorite artists. eg.: "NAME, "DATE"
         :param order_direction: Optional; A :class:`OrderDirection` describing the ordering direction when sorting by `order`. eg.: "ASC", "DESC"
@@ -592,7 +592,7 @@ class Favorites:
         order: Optional[AlbumOrder] = None,
         order_direction: Optional[OrderDirection] = None,
     ) -> List["Album"]:
-        """Get the users favorite albums, using pagination
+        """Get the users favorite albums, using pagination.
 
         :param order: Optional; A :class:`AlbumOrder` describing the ordering type when returning the user favorite albums. eg.: "NAME, "DATE"
         :param order_direction: Optional; A :class:`OrderDirection` describing the ordering direction when sorting by `order`. eg.: "ASC", "DESC"
@@ -633,7 +633,8 @@ class Favorites:
         order: Optional[PlaylistOrder] = None,
         order_direction: Optional[OrderDirection] = None,
     ) -> List["Playlist"]:
-        """Get the users favorite playlists relative to the root folder, using pagination
+        """Get the users favorite playlists relative to the root folder, using
+        pagination.
 
         :param order: Optional; A :class:`PlaylistOrder` describing the ordering type when returning the user favorite playlists. eg.: "NAME, "DATE"
         :param order_direction: Optional; A :class:`OrderDirection` describing the ordering direction when sorting by `order`. eg.: "ASC", "DESC"
@@ -728,7 +729,8 @@ class Favorites:
         order: Optional[ItemOrder] = None,
         order_direction: Optional[OrderDirection] = None,
     ) -> List["Playlist"]:
-        """Get the users favorite playlists relative to the root folder, using pagination
+        """Get the users favorite playlists relative to the root folder, using
+        pagination.
 
         :param order: Optional; A :class:`ItemOrder` describing the ordering type when returning the user favorite tracks. eg.: "NAME, "DATE"
         :param order_direction: Optional; A :class:`OrderDirection` describing the ordering direction when sorting by `order`. eg.: "ASC", "DESC"

--- a/tidalapi/user.py
+++ b/tidalapi/user.py
@@ -37,6 +37,7 @@ from tidalapi.types import (
     PlaylistOrder,
     VideoOrder,
 )
+from tidalapi.workers import get_items
 
 if TYPE_CHECKING:
     from tidalapi.album import Album
@@ -543,6 +544,19 @@ class Favorites:
         )
         return response.ok
 
+    def artists_paginated(
+        self,
+        order: Optional[ArtistOrder] = None,
+        order_direction: Optional[OrderDirection] = None,
+    ) -> List["Artist"]:
+        """Get the users favorite artists, using pagination
+
+        :param order: Optional; A :class:`ArtistOrder` describing the ordering type when returning the user favorite artists. eg.: "NAME, "DATE"
+        :param order_direction: Optional; A :class:`OrderDirection` describing the ordering direction when sorting by `order`. eg.: "ASC", "DESC"
+        :return: A :class:`list` :class:`~tidalapi.artist.Artist` objects containing the favorite artists.
+        """
+        return get_items(self.session.user.favorites.artists, order, order_direction)
+
     def artists(
         self,
         limit: Optional[int] = None,
@@ -573,6 +587,19 @@ class Favorites:
             ),
         )
 
+    def albums_paginated(
+        self,
+        order: Optional[AlbumOrder] = None,
+        order_direction: Optional[OrderDirection] = None,
+    ) -> List["Album"]:
+        """Get the users favorite albums, using pagination
+
+        :param order: Optional; A :class:`AlbumOrder` describing the ordering type when returning the user favorite albums. eg.: "NAME, "DATE"
+        :param order_direction: Optional; A :class:`OrderDirection` describing the ordering direction when sorting by `order`. eg.: "ASC", "DESC"
+        :return: A :class:`list` :class:`~tidalapi.album.Album` objects containing the favorite albums.
+        """
+        return get_items(self.session.user.favorites.albums, order, order_direction)
+
     def albums(
         self,
         limit: Optional[int] = None,
@@ -601,6 +628,19 @@ class Favorites:
             ),
         )
 
+    def playlists_paginated(
+        self,
+        order: Optional[PlaylistOrder] = None,
+        order_direction: Optional[OrderDirection] = None,
+    ) -> List["Playlist"]:
+        """Get the users favorite playlists relative to the root folder, using pagination
+
+        :param order: Optional; A :class:`PlaylistOrder` describing the ordering type when returning the user favorite playlists. eg.: "NAME, "DATE"
+        :param order_direction: Optional; A :class:`OrderDirection` describing the ordering direction when sorting by `order`. eg.: "ASC", "DESC"
+        :return: A :class:`list` :class:`~tidalapi.playlist.Playlist` objects containing the favorite playlists.
+        """
+        return get_items(self.session.user.favorites.playlists, order, order_direction)
+
     def playlists(
         self,
         limit: Optional[int] = 50,
@@ -609,6 +649,7 @@ class Favorites:
         order_direction: Optional[OrderDirection] = None,
     ) -> List["Playlist"]:
         """Get the users favorite playlists (v2 endpoint), relative to the root folder
+        This function is limited to 50 by TIDAL, requiring pagination.
 
         :param limit: Optional; The number of playlists you want returned (Note: Cannot exceed 50)
         :param offset: The index of the first playlist to fetch
@@ -681,6 +722,19 @@ class Favorites:
                 parse=self.session.parse_folder,
             ),
         )
+
+    def tracks_paginated(
+        self,
+        order: Optional[ItemOrder] = None,
+        order_direction: Optional[OrderDirection] = None,
+    ) -> List["Playlist"]:
+        """Get the users favorite playlists relative to the root folder, using pagination
+
+        :param order: Optional; A :class:`ItemOrder` describing the ordering type when returning the user favorite tracks. eg.: "NAME, "DATE"
+        :param order_direction: Optional; A :class:`OrderDirection` describing the ordering direction when sorting by `order`. eg.: "ASC", "DESC"
+        :return: A :class:`list` :class:`~tidalapi.playlist.Playlist` objects containing the favorite tracks.
+        """
+        return get_items(self.session.user.favorites.tracks, order, order_direction)
 
     def tracks(
         self,

--- a/tidalapi/workers.py
+++ b/tidalapi/workers.py
@@ -36,9 +36,9 @@ def get_items(
                     (
                         func,
                         offset,
-                        *args,
                         chunk_size,  # limit
                         offset,  # offset
+                        *args,  # extra args (e.g. order, order_direction)
                     )
                     for offset in offsets
                 ],

--- a/tidalapi/workers.py
+++ b/tidalapi/workers.py
@@ -15,11 +15,8 @@ def get_items(
     chunk_size: int = 50,
     processes: int = 5,
 ):
-    """
-    This function performs pagination on a function that supports
-    `limit`/`offset` parameters and it runs API requests in parallel to speed
-    things up.
-    """
+    """This function performs pagination on a function that supports `limit`/`offset`
+    parameters and it runs API requests in parallel to speed things up."""
     items = []
     offsets = [-chunk_size]
     remaining = chunk_size * processes

--- a/tidalapi/workers.py
+++ b/tidalapi/workers.py
@@ -1,10 +1,18 @@
+import logging
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable
+
+log = logging.getLogger(__name__)
 
 
 def func_wrapper(args):
     (f, offset, *args) = args
-    items = f(*args)
+    try:
+        items = f(*args)
+    except Exception as e:
+        log.error("Failed to run %s(offset=%d, args=%s)", f, offset, args)
+        log.exception(e)
+        items = []
     return list((i + offset, item) for i, item in enumerate(items))
 
 
@@ -13,7 +21,7 @@ def get_items(
     *args,
     parse: Callable = lambda _: _,
     chunk_size: int = 50,
-    processes: int = 5,
+    processes: int = 2,
 ):
     """This function performs pagination on a function that supports `limit`/`offset`
     parameters and it runs API requests in parallel to speed things up."""

--- a/tidalapi/workers.py
+++ b/tidalapi/workers.py
@@ -1,0 +1,59 @@
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable
+
+
+def func_wrapper(args):
+    (f, offset, *args) = args
+    items = f(*args)
+    return list((i + offset, item) for i, item in enumerate(items))
+
+
+def get_items(
+    func: Callable,
+    *args,
+    parse: Callable = lambda _: _,
+    chunk_size: int = 50,
+    processes: int = 5,
+):
+    """
+    This function performs pagination on a function that supports
+    `limit`/`offset` parameters and it runs API requests in parallel to speed
+    things up.
+    """
+    items = []
+    offsets = [-chunk_size]
+    remaining = chunk_size * processes
+
+    with ThreadPoolExecutor(
+        processes, thread_name_prefix=f"mopidy-tidal-{func.__name__}-"
+    ) as pool:
+        while remaining == chunk_size * processes:
+            offsets = [offsets[-1] + chunk_size * (i + 1) for i in range(processes)]
+
+            pool_results = pool.map(
+                func_wrapper,
+                [
+                    (
+                        func,
+                        offset,
+                        *args,
+                        chunk_size,  # limit
+                        offset,  # offset
+                    )
+                    for offset in offsets
+                ],
+            )
+
+            new_items = []
+            for results in pool_results:
+                new_items.extend(results)
+
+            remaining = len(new_items)
+            items.extend(new_items)
+
+    items = [_ for _ in items if _]
+    sorted_items = list(
+        map(lambda item: item[1], sorted(items, key=lambda item: item[0]))
+    )
+
+    return list(map(parse, sorted_items))


### PR DESCRIPTION
* [Move "data" field validation/fallback for consistency.](https://github.com/EbbLabs/python-tidal/commit/f81e67282f9521f80ad3a71ee436348a5cc63078)
* [Playlists: Ensure only PLAYLIST types are returned when fetching from](https://github.com/EbbLabs/python-tidal/commit/faa76d36660416fc33cfe4e7b6320705beb5b984). Fixes #345 , #349 
* [Moved get playlist_folders() helper for consistency.](https://github.com/EbbLabs/python-tidal/commit/f86a2fc03d6761e1a9679670e3cb599888d5e8d6)
* [Add workers from mopidy-tidal](https://github.com/EbbLabs/python-tidal/commit/227a46413aba561c0185ef06cdd208dcf776044a). 
* [Rearrange args (order, order_direction should be last)](https://github.com/EbbLabs/python-tidal/commit/f8c151f069792e7a8a74606aff5b58a943859146)
* [Add paginated getters for artists, albums, playlists and tracks](https://github.com/EbbLabs/python-tidal/commit/ec3b40d33f746799333b881fc5430ae4bcfa9e2a). Fixes #265 